### PR TITLE
Using a file walk to discover files recursively

### DIFF
--- a/tst/com/amazon/kinesis/streaming/agent/tailing/SourceFileTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/tailing/SourceFileTest.java
@@ -138,6 +138,20 @@ public class SourceFileTest extends TestBase {
         Assert.assertEquals(src.listFiles().size(), 0);
     }
 
+    @Test
+    public void testListFoldersRecursively() throws IOException {
+        Path test = Files.createTempDirectory("test");
+        Path one = Files.createDirectory(test.resolve("something1"));
+        Path two = Files.createDirectory(test.resolve("something2"));
+        Files.createFile(one.resolve("a.log"));
+        Files.createFile(two.resolve("a.log"));
+        SourceFile src = new SourceFile(null, test.toString() + "/*");
+        TrackedFileList trackedFiles = src.listFiles();
+        Assert.assertEquals(trackedFiles.size(), 2);
+        Path[] expectedFiles = new Path[] {one.resolve("a.log"), two.resolve("a.log")};
+        Assert.assertEquals(toPathList(trackedFiles).toArray(), expectedFiles);
+    }
+
     @Test(dataProvider = "listAndCountFiles")
     public void testCountFiles(String fileGlob, String[] matchingNames, String[] nonMatchingNames)
             throws InterruptedException, IOException {


### PR DESCRIPTION
Using a file walk to discover files recursively. This allows us to use the collector on EMR, where are buried deep inside dynamically generated folders.

Tested on an EC2 instance, and it build and picks up new files successfully. 

The project uses Java 7, so I sticked to that, which is why I can't use the `Files.walk` method. 