### PR TITLE
Fixed OS system identification

### DIFF
--- a/setup
+++ b/setup
@@ -6,16 +6,23 @@ set -e
 # If we're debugging, be really loudly verbose
 [[ ! -z $DEBUG ]] && set -x
 
-# Attempt to load up the /etc/lsb-release file to determine our OS. If none is
+# Attempt to determine our OS from /etc/os-release. If none is
 # found, we default our settings to RHEL/Amazon Linux as the original behavior
 # of this script intended.
-if [[ -f /etc/lsb-release ]]; then
-  dist=Ubuntu
-elif [[ -f /etc/debian_version ]]; then
-  dist=Debian
-else
+case $(grep '^ID=' < /etc/os-release | cut -d'=' -f2) in
+*amzn*)
   dist=RedHat
-fi
+  ;;
+*ubuntu*)
+  dist=Ubuntu
+  ;;
+*debian*)
+  dist=Debian
+  ;;
+*)
+  dist=RedHat
+  ;;
+esac
 
 # Tell the user what OS we detected
 echo "Detected OS Distro: ${dist}"


### PR DESCRIPTION
On EMR nodes, the `etc/lsb-release` file exists, which was causing the OS to be incorrectly identified as Ubuntu. This causes the setup script to fail as it uses the wrong executables (`apt-get` instead of `yum` etc)

This PR uses the info inside `etc/os-release` as that is the standard way of reporting the distro info. This works as expected on Amazon's EMR node and on the Ubuntu nodes.