### PR TITLE
Matching paths, not file names

### DIFF
--- a/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
+++ b/src/com/amazon/kinesis/streaming/agent/tailing/SourceFile.java
@@ -47,11 +47,10 @@ public class SourceFile {
         this.flow = flow;
         // fileName
         Preconditions.checkArgument(!filePattern.endsWith("/"), "File name component is empty!");
-        Path filePath = FileSystems.getDefault().getPath(filePattern);
+        this.filePattern = FileSystems.getDefault().getPath(filePattern);
         // TODO: this does not handle globs in directory component: e.g. /opt/*/logs/app.log, /opt/**/app.log*
-        this.directory = filePath.getParent();
+        this.directory = this.filePattern.getParent();
         validateDirectory(this.directory);
-        this.filePattern = filePath.getFileName();
         this.pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + this.filePattern.toString());
     }
 
@@ -79,7 +78,7 @@ public class SourceFile {
 
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                if (pathMatcher.matches(file.getFileName()) && validateFile(file)) {
+                if (pathMatcher.matches(file) && validateFile(file)) {
                     files.add(new TrackedFile(flow, file));
                 }
                 return FileVisitResult.CONTINUE;

--- a/tst/com/amazon/kinesis/streaming/agent/tailing/SourceFileTest.java
+++ b/tst/com/amazon/kinesis/streaming/agent/tailing/SourceFileTest.java
@@ -152,6 +152,20 @@ public class SourceFileTest extends TestBase {
         Assert.assertEquals(toPathList(trackedFiles).toArray(), expectedFiles);
     }
 
+    @Test
+    public void testMatchFilesInRecursiveSearch() throws IOException {
+        Path test = Files.createTempDirectory("test");
+        Path one = Files.createDirectories(test.resolve("something1/else/here"));
+        Path two = Files.createDirectories(test.resolve("something2/where/is/this/file"));
+        Files.createFile(one.resolve("a.log"));
+        Files.createFile(two.resolve("a.log"));
+        SourceFile src = new SourceFile(null, test.toString() + "/something**");
+        TrackedFileList trackedFiles = src.listFiles();
+        Assert.assertEquals(trackedFiles.size(), 2);
+        Path[] expectedFiles = new Path[] {one.resolve("a.log"), two.resolve("a.log")};
+        Assert.assertEquals(toPathList(trackedFiles).toArray(), expectedFiles);
+    }
+
     @Test(dataProvider = "listAndCountFiles")
     public void testCountFiles(String fileGlob, String[] matchingNames, String[] nonMatchingNames)
             throws InterruptedException, IOException {


### PR DESCRIPTION
The assumption seems to be that you'd like to match individual file names. This doesn't work for us, as we want to recursively match any fixes that match the a given prefix.

Changed the logic to match path globs, and added a test that replicates EMR's setup and reproduces the error.


